### PR TITLE
Fix/getty eof

### DIFF
--- a/protocol/dubbo/impl/codec.go
+++ b/protocol/dubbo/impl/codec.go
@@ -157,7 +157,7 @@ func (c *ProtocolCodec) Decode(p *DubboPackage) error {
 			return err
 		}
 	}
-	if c.reader.Size() < p.GetBodyLen() {
+	if c.reader.Size() < p.GetBodyLen()+HEADER_LENGTH {
 		return hessian.ErrBodyNotEnough
 	}
 	body, err := c.reader.Peek(p.GetBodyLen())

--- a/protocol/dubbo/impl/codec.go
+++ b/protocol/dubbo/impl/codec.go
@@ -157,6 +157,9 @@ func (c *ProtocolCodec) Decode(p *DubboPackage) error {
 			return err
 		}
 	}
+	if c.reader.Size() < p.GetBodyLen() {
+		return hessian.ErrBodyNotEnough
+	}
 	body, err := c.reader.Peek(p.GetBodyLen())
 	if err != nil {
 		return err

--- a/protocol/dubbo/impl/const.go
+++ b/protocol/dubbo/impl/const.go
@@ -223,6 +223,8 @@ var (
 
 // Error part
 var (
+	// the following errors has already existed in github.com/apache/dubbo-go-hessian2.
+	// Please do not use them.
 	ErrHeaderNotEnough = errors.New("header buffer too short")
 	ErrBodyNotEnough   = errors.New("body buffer too short")
 	ErrJavaException   = errors.New("got java exception")

--- a/remoting/codec.go
+++ b/remoting/codec.go
@@ -26,7 +26,7 @@ import (
 type Codec interface {
 	EncodeRequest(request *Request) (*bytes.Buffer, error)
 	EncodeResponse(response *Response) (*bytes.Buffer, error)
-	Decode(data []byte) (DecodeResult, int, error)
+	Decode(data []byte) (*DecodeResult, int, error)
 }
 
 type DecodeResult struct {

--- a/remoting/getty/dubbo_codec_for_test.go
+++ b/remoting/getty/dubbo_codec_for_test.go
@@ -155,19 +155,19 @@ func (c *DubboTestCodec) EncodeResponse(response *remoting.Response) (*bytes.Buf
 }
 
 // Decode data, including request and response.
-func (c *DubboTestCodec) Decode(data []byte) (remoting.DecodeResult, int, error) {
+func (c *DubboTestCodec) Decode(data []byte) (*remoting.DecodeResult, int, error) {
 	if c.isRequest(data) {
 		req, len, err := c.decodeRequest(data)
 		if err != nil {
-			return remoting.DecodeResult{}, len, perrors.WithStack(err)
+			return &remoting.DecodeResult{}, len, perrors.WithStack(err)
 		}
-		return remoting.DecodeResult{IsRequest: true, Result: req}, len, perrors.WithStack(err)
+		return &remoting.DecodeResult{IsRequest: true, Result: req}, len, perrors.WithStack(err)
 	} else {
 		resp, len, err := c.decodeResponse(data)
 		if err != nil {
-			return remoting.DecodeResult{}, len, perrors.WithStack(err)
+			return &remoting.DecodeResult{}, len, perrors.WithStack(err)
 		}
-		return remoting.DecodeResult{IsRequest: false, Result: resp}, len, perrors.WithStack(err)
+		return &remoting.DecodeResult{IsRequest: false, Result: resp}, len, perrors.WithStack(err)
 	}
 }
 

--- a/remoting/getty/listener.go
+++ b/remoting/getty/listener.go
@@ -94,8 +94,8 @@ func (h *RpcClientHandler) OnClose(session getty.Session) {
 
 // OnMessage get response from getty server, and update the session to the getty client session list
 func (h *RpcClientHandler) OnMessage(session getty.Session, pkg interface{}) {
-	result, ok := pkg.(remoting.DecodeResult)
-	if !ok {
+	result, ok := pkg.(*remoting.DecodeResult)
+	if !ok || result == ((*remoting.DecodeResult)(nil)) {
 		logger.Errorf("[RpcClientHandler.OnMessage] getty client gets an unexpected rpc result: %#v", result)
 		return
 	}
@@ -232,8 +232,8 @@ func (h *RpcServerHandler) OnMessage(session getty.Session, pkg interface{}) {
 	}
 	h.rwlock.Unlock()
 
-	decodeResult, drOK := pkg.(remoting.DecodeResult)
-	if !drOK {
+	decodeResult, drOK := pkg.(*remoting.DecodeResult)
+	if !drOK || decodeResult == ((*remoting.DecodeResult)(nil)) {
 		logger.Errorf("illegal package{%#v}", pkg)
 		return
 	}

--- a/remoting/getty/readwriter.go
+++ b/remoting/getty/readwriter.go
@@ -49,7 +49,10 @@ func (p *RpcClientPackageHandler) Read(ss getty.Session, data []byte) (interface
 	if err != nil {
 		err = perrors.WithStack(err)
 	}
-	if rsp.Result == nil {
+	if rsp == ((*remoting.DecodeResult)(nil)) {
+		return nil, length, err
+	}
+	if rsp.Result == ((*remoting.Response)(nil)) || rsp.Result == ((*remoting.Request)(nil)) {
 		return nil, length, err
 	}
 	return rsp, length, err
@@ -97,7 +100,10 @@ func (p *RpcServerPackageHandler) Read(ss getty.Session, data []byte) (interface
 	if err != nil {
 		err = perrors.WithStack(err)
 	}
-	if req.Result == nil {
+	if req == ((*remoting.DecodeResult)(nil)) {
+		return nil, length, err
+	}
+	if req.Result == ((*remoting.Request)(nil)) || req.Result == ((*remoting.Response)(nil)) {
 		return nil, length, err // as getty rule
 	}
 	return req, length, err

--- a/remoting/getty/readwriter_test.go
+++ b/remoting/getty/readwriter_test.go
@@ -75,8 +75,8 @@ func testDecodeTCPPackage(t *testing.T, svr *Server, client *Client) {
 	assert.True(t, incompletePkgLen >= impl.HEADER_LENGTH, "header buffer too short")
 	incompletePkg := pkgBytes[0 : incompletePkgLen-1]
 	pkg, pkgLen, err := pkgReadHandler.Read(nil, incompletePkg)
-	assert.NoError(t, err)
-	assert.Equal(t, pkg, nil)
+	assert.Equal(t, err.Error(), "body buffer too short")
+	assert.Equal(t, pkg.(*remoting.DecodeResult).Result, nil)
 	assert.Equal(t, pkgLen, 0)
 }
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!
Read https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md before commit pull request.
-->

**What this PR does**: 

**Which issue(s) this PR fixes**: 
Fixes #

**You should pay attention to items below to ensure your pr passes our ci test**
We do not merge pr with ci tests failed

- [ ] All ut passed (run 'go test ./...' in project root)
- [ ] After go-fmt ed , run 'go fmt project' using goland.
- [ ] Golangci-lint passed, run 'sudo golangci-lint run' in project root.
- [ ] After import formatted, (using [imports-formatter](https://github.com/dubbogo/tools#5-how-to-get-imports-formatter) to run 'imports-formatter .' in project root, to format your import blocks, mentioned in [CONTRIBUTING.md](https://github.com/apache/dubbo-go/blob/master/CONTRIBUTING.md) above) 
- [ ] Your new-created file needs to have [apache license](https://raw.githubusercontent.com/dubbogo/resources/master/tools/license/license.txt) at the top, like other existed file does.
- [ ] All integration test passed. You can run integration test locally (with docker env). Clone our [dubbo-go-samples](https://github.com/apache/dubbo-go-samples) project and replace the go.mod to your dubbo-go, and run 'sudo sh start_integration_test.sh' at root of samples project root. (M1 Slice is not Support)